### PR TITLE
fix: denicker display message in wrong order

### DIFF
--- a/src/main/java/org/afterlike/openutils/module/impl/hypixel/DenickerModule.java
+++ b/src/main/java/org/afterlike/openutils/module/impl/hypixel/DenickerModule.java
@@ -312,7 +312,7 @@ public class DenickerModule extends Module {
 			}
 		}
 		if (denicked) {
-			ClientUtil.sendMessage("§e" + displayName + " §7is nicked as §a" + realName + "§7.");
+			ClientUtil.sendMessage("§e" + realName + " §7is nicked as §a" + displayName + "§7.");
 		} else if (showFailed.getValue()) {
 			ClientUtil.sendMessage("§e" + displayName + " §cis nicked.");
 		}


### PR DESCRIPTION
It should be `real_ign is nicked as nicked_ign`. The chat message lists them in the wrong order.

<details> 
  <summary>PS</summary>
   isn't openutils just a hack client? No break delay and others don't exactly seem like a "common gameplay utilities".
</details>